### PR TITLE
Update main.neva

### DIFF
--- a/main/main.neva
+++ b/main/main.neva
@@ -3,5 +3,6 @@ import { fmt }
 pub def Println<T>(data T) (res T, err error) {
     println fmt.Println<T>?
     ---
-    :data -> println -> :res
+    :data -> println
+    println:res -> :res
 }


### PR DESCRIPTION
Because println will have 2 outports (res and err), we need to specify, which outport we want to pipe into res. Otherwise this won't compile.